### PR TITLE
Fix: Signup login

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 	implementation 'mysql:mysql-connector-java'
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	implementation 'org.projectlombok:lombok:1.18.22'
+	implementation 'com.auth0:java-jwt:4.0.0'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/src/main/java/jupgo/jupgoserver/controller/DiaryController.java
+++ b/src/main/java/jupgo/jupgoserver/controller/DiaryController.java
@@ -3,16 +3,12 @@ package jupgo.jupgoserver.controller;
 import static jupgo.jupgoserver.util.response.StatusCode.OK;
 import static jupgo.jupgoserver.util.response.StatusMessage.*;
 
-import jupgo.jupgoserver.domain.diary.Diary;
 import jupgo.jupgoserver.dto.diary.SaveDiaryRequestDto;
 import jupgo.jupgoserver.dto.diary.SaveDiaryResponseDto;
 import jupgo.jupgoserver.service.DiaryService;
 import jupgo.jupgoserver.service.S3Service;
-import jupgo.jupgoserver.util.response.StatusCode;
-import jupgo.jupgoserver.util.response.StatusMessage;
-import jupgo.jupgoserver.util.response.SuccessResponse;
+import jupgo.jupgoserver.util.response.Response;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -20,7 +16,6 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.multipart.MultipartFile;
 
-@Controller
 @RequestMapping("/api/diary")
 public class DiaryController {
     @Autowired
@@ -30,13 +25,13 @@ public class DiaryController {
 
     @ResponseBody
     @PostMapping()
-    public SuccessResponse saveDiary(
+    public Response saveDiary(
             @RequestPart("diaryData") SaveDiaryRequestDto saveDiaryRequestDto,
             @RequestParam("file") MultipartFile file)
             throws Exception {
         String fileLink = s3Service.getLinkAfterSaveUploadFile(file);
         saveDiaryRequestDto.setPhoto(fileLink);
         SaveDiaryResponseDto saveDiaryResponseDto = diaryService.saveDiary(saveDiaryRequestDto);
-        return new SuccessResponse(OK.getCode(), PLOGGING_SAVE_SUCCESS.getMessage(), saveDiaryResponseDto);
+        return new Response(OK.getCode(), PLOGGING_SAVE_SUCCESS.getMessage(), saveDiaryResponseDto);
     }
 }

--- a/src/main/java/jupgo/jupgoserver/controller/UserController.java
+++ b/src/main/java/jupgo/jupgoserver/controller/UserController.java
@@ -1,23 +1,76 @@
 package jupgo.jupgoserver.controller;
 
-import com.google.gson.JsonObject;
+import com.fasterxml.jackson.databind.JsonNode;
+import jupgo.jupgoserver.domain.user.User;
+import jupgo.jupgoserver.dto.user.SaveUserRequestDto;
+import jupgo.jupgoserver.dto.user.SaveUserResponseDto;
+import jupgo.jupgoserver.service.AuthService;
+import jupgo.jupgoserver.service.KakaoService;
 import jupgo.jupgoserver.service.UserService;
+import jupgo.jupgoserver.util.response.Response;
+import jupgo.jupgoserver.util.response.StatusMessage;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Map;
+import static jupgo.jupgoserver.util.response.StatusCode.*;
+import static jupgo.jupgoserver.util.response.StatusCode.INTERNAL_ERROR;
+import static jupgo.jupgoserver.util.response.StatusMessage.SIGNUP_SUCCESS;
 
 @Controller
 @RequestMapping("/api/user")
 public class UserController {
+
     @Autowired
     private UserService userService;
 
+    @Autowired
+    private KakaoService kakaoService;
+    @Autowired
+    private AuthService authService;
+
+
     @ResponseBody
-    @GetMapping("/login")
-    public void login(@RequestParam String code) throws Exception {
-        String access_Token = userService.getKaKaoAccessToken(code);
-        userService.createKakaoUser(access_Token);
+    @PostMapping("/login")
+    public Response login(@RequestBody String accessToken) {
+        try {
+            return new Response(OK.getCode(), StatusMessage.LOGIN_SUCCESS.getMessage(), authService.kakaoLogin(accessToken));
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+            return new Response(INTERNAL_ERROR.getCode(), StatusMessage.INTERNAL_ERROR.getMessage());
+        }
+    }
+
+    @ResponseBody
+    @PostMapping("/signup")
+    public Response signup(@RequestBody SaveUserRequestDto saveUserRequestDto) {
+        JsonNode userInfo = kakaoService.verifyAccessToken(saveUserRequestDto.getAccessToken());
+        String email = userInfo.path("kakao_account").path("email").asText();
+        System.out.println("email : " + email);
+        saveUserRequestDto.setKakaoId(userInfo.path("id").asInt());
+
+        JsonNode kakao_account = userInfo.path("kakao_account");
+        if (kakao_account.path("has_email").asBoolean() && kakao_account.path("is_email_valid").asBoolean() && kakao_account.path("is_email_verified").asBoolean()) {
+            saveUserRequestDto.setEmail(kakao_account.path("email").asText());
+        }
+
+        JsonNode properties = userInfo.path("properties");
+        if(properties.path("nickname").asText()!=null) {
+            saveUserRequestDto.setNickname(properties.path("nickname").asText());
+            System.out.println("nickname: "+userInfo.path("nickname").asText());
+        } else{
+            saveUserRequestDto.setNickname("no_name");
+            System.out.println("no_name");
+        }
+
+        try {
+            SaveUserResponseDto saveUserResponseDto = userService.save(saveUserRequestDto);
+            return new Response(OK.getCode(), SIGNUP_SUCCESS.getMessage(), saveUserResponseDto);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return new Response(INTERNAL_ERROR.getCode(), StatusMessage.INTERNAL_ERROR.getMessage());
+        }
     }
 }

--- a/src/main/java/jupgo/jupgoserver/controller/UserController.java
+++ b/src/main/java/jupgo/jupgoserver/controller/UserController.java
@@ -1,73 +1,27 @@
 package jupgo.jupgoserver.controller;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import jupgo.jupgoserver.domain.user.User;
-import jupgo.jupgoserver.dto.user.SaveUserRequestDto;
-import jupgo.jupgoserver.dto.user.SaveUserResponseDto;
 import jupgo.jupgoserver.service.AuthService;
-import jupgo.jupgoserver.service.KakaoService;
-import jupgo.jupgoserver.service.UserService;
 import jupgo.jupgoserver.util.response.Response;
 import jupgo.jupgoserver.util.response.StatusMessage;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import static jupgo.jupgoserver.util.response.StatusCode.*;
 import static jupgo.jupgoserver.util.response.StatusCode.INTERNAL_ERROR;
-import static jupgo.jupgoserver.util.response.StatusMessage.SIGNUP_SUCCESS;
 
 @Controller
 @RequestMapping("/api/user")
 public class UserController {
-
-    @Autowired
-    private UserService userService;
-
-    @Autowired
-    private KakaoService kakaoService;
     @Autowired
     private AuthService authService;
 
 
     @ResponseBody
-    @PostMapping("/login")
-    public Response login(@RequestBody String accessToken) {
+    @GetMapping("/login")
+    public Response login(@RequestParam String code) {
         try {
-            return new Response(OK.getCode(), StatusMessage.LOGIN_SUCCESS.getMessage(), authService.kakaoLogin(accessToken));
-        }
-        catch (Exception e) {
-            e.printStackTrace();
-            return new Response(INTERNAL_ERROR.getCode(), StatusMessage.INTERNAL_ERROR.getMessage());
-        }
-    }
-
-    @ResponseBody
-    @PostMapping("/signup")
-    public Response signup(@RequestBody SaveUserRequestDto saveUserRequestDto) {
-        JsonNode userInfo = kakaoService.verifyAccessToken(saveUserRequestDto.getAccessToken());
-        String email = userInfo.path("kakao_account").path("email").asText();
-        System.out.println("email : " + email);
-        saveUserRequestDto.setKakaoId(userInfo.path("id").asInt());
-
-        JsonNode kakao_account = userInfo.path("kakao_account");
-        if (kakao_account.path("has_email").asBoolean() && kakao_account.path("is_email_valid").asBoolean() && kakao_account.path("is_email_verified").asBoolean()) {
-            saveUserRequestDto.setEmail(kakao_account.path("email").asText());
-        }
-
-        JsonNode properties = userInfo.path("properties");
-        if(properties.path("nickname").asText()!=null) {
-            saveUserRequestDto.setNickname(properties.path("nickname").asText());
-            System.out.println("nickname: "+userInfo.path("nickname").asText());
-        } else{
-            saveUserRequestDto.setNickname("no_name");
-            System.out.println("no_name");
-        }
-
-        try {
-            SaveUserResponseDto saveUserResponseDto = userService.save(saveUserRequestDto);
-            return new Response(OK.getCode(), SIGNUP_SUCCESS.getMessage(), saveUserResponseDto);
+            return new Response(OK.getCode(), StatusMessage.LOGIN_SUCCESS.getMessage(), authService.kakaoLogin(code));
         } catch (Exception e) {
             e.printStackTrace();
             return new Response(INTERNAL_ERROR.getCode(), StatusMessage.INTERNAL_ERROR.getMessage());

--- a/src/main/java/jupgo/jupgoserver/domain/user/User.java
+++ b/src/main/java/jupgo/jupgoserver/domain/user/User.java
@@ -7,7 +7,6 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import jupgo.jupgoserver.domain.tree.Tree;
-import jupgo.jupgoserver.dto.diary.SaveDiaryRequestDto;
 import jupgo.jupgoserver.dto.user.SaveUserRequestDto;
 
 @Entity

--- a/src/main/java/jupgo/jupgoserver/domain/user/User.java
+++ b/src/main/java/jupgo/jupgoserver/domain/user/User.java
@@ -7,6 +7,8 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import jupgo.jupgoserver.domain.tree.Tree;
+import jupgo.jupgoserver.dto.diary.SaveDiaryRequestDto;
+import jupgo.jupgoserver.dto.user.SaveUserRequestDto;
 
 @Entity
 public class User {
@@ -14,13 +16,22 @@ public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
     private String nickname;
-
     private String email;
+    private Integer kakaoId;
+
 
     @OneToMany(mappedBy = "user")
     private List<Tree> trees;
+
+    public User(SaveUserRequestDto saveUserRequestDto) {
+        this.nickname = saveUserRequestDto.getNickname();
+        this.email = saveUserRequestDto.getEmail();
+        this.kakaoId = saveUserRequestDto.getKakaoId();
+    }
+
+    public User() {}
+
 
     public Long getId() {
         return id;
@@ -44,5 +55,13 @@ public class User {
 
     public void setEmail(String email) {
         this.email = email;
+    }
+
+    public Integer getKakaoId() {
+        return kakaoId;
+    }
+
+    public void setKakaoId(Integer kakaoId) {
+        this.kakaoId = kakaoId;
     }
 }

--- a/src/main/java/jupgo/jupgoserver/dto/user/SaveUserRequestDto.java
+++ b/src/main/java/jupgo/jupgoserver/dto/user/SaveUserRequestDto.java
@@ -1,0 +1,31 @@
+package jupgo.jupgoserver.dto.user;
+
+import lombok.Data;
+
+@Data
+public class SaveUserRequestDto {
+    private Long id;
+    private String nickname;
+
+    private String email;
+    private Integer kakaoId;
+    private String accessToken;
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+
+}

--- a/src/main/java/jupgo/jupgoserver/dto/user/SaveUserRequestDto.java
+++ b/src/main/java/jupgo/jupgoserver/dto/user/SaveUserRequestDto.java
@@ -9,7 +9,8 @@ public class SaveUserRequestDto {
 
     private String email;
     private Integer kakaoId;
-    private String accessToken;
+
+    private String code;
 
     public String getNickname() {
         return nickname;
@@ -25,6 +26,14 @@ public class SaveUserRequestDto {
 
     public void setEmail(String email) {
         this.email = email;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
     }
 
 

--- a/src/main/java/jupgo/jupgoserver/dto/user/SaveUserResponseDto.java
+++ b/src/main/java/jupgo/jupgoserver/dto/user/SaveUserResponseDto.java
@@ -1,0 +1,17 @@
+package jupgo.jupgoserver.dto.user;
+
+import jupgo.jupgoserver.domain.diary.Diary;
+import jupgo.jupgoserver.domain.user.User;
+
+public class SaveUserResponseDto {
+
+    private Long id;
+
+    public SaveUserResponseDto(User user) {
+        this.id = user.getId();
+    }
+
+    public Long getId() {
+        return id;
+    }
+}

--- a/src/main/java/jupgo/jupgoserver/repository/UserRepository.java
+++ b/src/main/java/jupgo/jupgoserver/repository/UserRepository.java
@@ -1,9 +1,10 @@
 package jupgo.jupgoserver.repository;
 import jupgo.jupgoserver.domain.user.User;
 import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+import java.util.List;
 import java.util.Optional;
 
-import jupgo.jupgoserver.dto.user.SaveUserRequestDto;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -19,8 +20,11 @@ public class UserRepository {
         return user;
     }
 
-    public User findByKakaoUserId(Integer kakaoUserId) {
-        User user = em.find(User.class, kakaoUserId);
-        return user;
+    public List<User> findByKakaoUserId(Integer kakaoUserId) {
+        List<User> result = em.createQuery("select u from User u where u.kakaoId = :kakaoUserId", User.class)
+                .setParameter("kakaoUserId", kakaoUserId)
+                .getResultList();
+        return result;
     }
+
 }

--- a/src/main/java/jupgo/jupgoserver/repository/UserRepository.java
+++ b/src/main/java/jupgo/jupgoserver/repository/UserRepository.java
@@ -2,6 +2,8 @@ package jupgo.jupgoserver.repository;
 import jupgo.jupgoserver.domain.user.User;
 import javax.persistence.EntityManager;
 import java.util.Optional;
+
+import jupgo.jupgoserver.dto.user.SaveUserRequestDto;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -17,8 +19,8 @@ public class UserRepository {
         return user;
     }
 
-    public Optional<User> findByEmail(String email) {
-        User user = em.find(User.class, email);
-        return Optional.ofNullable(user);
+    public User findByKakaoUserId(Integer kakaoUserId) {
+        User user = em.find(User.class, kakaoUserId);
+        return user;
     }
 }

--- a/src/main/java/jupgo/jupgoserver/service/AuthService.java
+++ b/src/main/java/jupgo/jupgoserver/service/AuthService.java
@@ -2,45 +2,71 @@ package jupgo.jupgoserver.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import jupgo.jupgoserver.domain.user.User;
+import jupgo.jupgoserver.dto.user.SaveUserResponseDto;
 import jupgo.jupgoserver.repository.UserRepository;
-import jupgo.jupgoserver.util.response.Response;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import static jupgo.jupgoserver.util.response.StatusCode.*;
-import static jupgo.jupgoserver.util.response.StatusMessage.LOGIN_FAIL;
-import static jupgo.jupgoserver.util.response.StatusMessage.LOGIN_SUCCESS;
+import javax.transaction.Transactional;
+import java.util.List;
 
 @Service
 @Slf4j
+@Transactional
 public class AuthService {
 
     private final UserRepository userRepository;
     private final JwtService jwtService;
     private final KakaoService kakaoService;
+    private final UserService userService;
 
-    public AuthService(UserRepository userRepository, JwtService jwtService, KakaoService kakaoService) {
+    public AuthService(UserRepository userRepository, JwtService jwtService, KakaoService kakaoService, UserService userService) {
         this.userRepository = userRepository;
         this.jwtService = jwtService;
         this.kakaoService = kakaoService;
+        this.userService = userService;
     }
 
-    public Response<JwtService.TokenRes> kakaoLogin(final String accessToken) {
+    public JwtService.TokenRes kakaoLogin(final String code) {
         int userKakaoId = -1;
-            JsonNode userInfo = kakaoService.verifyAccessToken(accessToken);
-            if(!userInfo.path("id").isMissingNode()){
-                userKakaoId = userInfo.path("id").asInt();
-            }else {
-                return new Response(BAD_REQUEST.getCode(), LOGIN_FAIL.getMessage());
-            }
-        final User user = userRepository.findByKakaoUserId(userKakaoId);
-        if(user!=null){
-            Long userId = user.getId();
-            final JwtService.TokenRes tokenDto = new JwtService.TokenRes(jwtService.create(userId));
-            return new Response(OK.getCode(), LOGIN_SUCCESS.getMessage(), tokenDto);
+        String accessToken = kakaoService.verifyAccessToken(code);
+        JsonNode userInfo = kakaoService.getUserInfo(accessToken);
+        if (!userInfo.path("id").isMissingNode()) {
+            userKakaoId = userInfo.path("id").asInt();
         }
-        return new Response(NOT_FOUND.getCode(), LOGIN_FAIL.getMessage());
+        List<User> user = userRepository.findByKakaoUserId(userKakaoId);
+        System.out.println(userInfo);
+        if (!user.isEmpty()) {
+            Long userId = user.get(0).getId();
+            final JwtService.TokenRes tokenDto = new JwtService.TokenRes(jwtService.create(userId));
+            return tokenDto;
+        } else {
+            User newUser = new User();
+            String email = userInfo.path("kakao_account").path("email").asText();
+            newUser.setKakaoId(userInfo.path("id").asInt());
+
+            JsonNode kakao_account = userInfo.path("kakao_account");
+            if (kakao_account.path("has_email").asBoolean() && kakao_account.path("is_email_valid").asBoolean() && kakao_account.path("is_email_verified").asBoolean()) {
+                newUser.setEmail(kakao_account.path("email").asText());
+            }
+
+            JsonNode properties = userInfo.path("properties");
+            if (properties.path("nickname").asText() != null) {
+                newUser.setNickname(properties.path("nickname").asText());
+                System.out.println("nickname: " + properties.path("nickname").asText());
+            } else {
+                newUser.setNickname("no_name");
+                System.out.println("no_name");
+            }
+
+            try {
+                SaveUserResponseDto saveUserResponseDto = userService.save(newUser);
+                final JwtService.TokenRes tokenDto = new JwtService.TokenRes(jwtService.create(saveUserResponseDto.getId()));
+                return tokenDto;
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+        return null;
     }
-
-
 }

--- a/src/main/java/jupgo/jupgoserver/service/AuthService.java
+++ b/src/main/java/jupgo/jupgoserver/service/AuthService.java
@@ -1,0 +1,46 @@
+package jupgo.jupgoserver.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import jupgo.jupgoserver.domain.user.User;
+import jupgo.jupgoserver.repository.UserRepository;
+import jupgo.jupgoserver.util.response.Response;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import static jupgo.jupgoserver.util.response.StatusCode.*;
+import static jupgo.jupgoserver.util.response.StatusMessage.LOGIN_FAIL;
+import static jupgo.jupgoserver.util.response.StatusMessage.LOGIN_SUCCESS;
+
+@Service
+@Slf4j
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final JwtService jwtService;
+    private final KakaoService kakaoService;
+
+    public AuthService(UserRepository userRepository, JwtService jwtService, KakaoService kakaoService) {
+        this.userRepository = userRepository;
+        this.jwtService = jwtService;
+        this.kakaoService = kakaoService;
+    }
+
+    public Response<JwtService.TokenRes> kakaoLogin(final String accessToken) {
+        int userKakaoId = -1;
+            JsonNode userInfo = kakaoService.verifyAccessToken(accessToken);
+            if(!userInfo.path("id").isMissingNode()){
+                userKakaoId = userInfo.path("id").asInt();
+            }else {
+                return new Response(BAD_REQUEST.getCode(), LOGIN_FAIL.getMessage());
+            }
+        final User user = userRepository.findByKakaoUserId(userKakaoId);
+        if(user!=null){
+            Long userId = user.getId();
+            final JwtService.TokenRes tokenDto = new JwtService.TokenRes(jwtService.create(userId));
+            return new Response(OK.getCode(), LOGIN_SUCCESS.getMessage(), tokenDto);
+        }
+        return new Response(NOT_FOUND.getCode(), LOGIN_FAIL.getMessage());
+    }
+
+
+}

--- a/src/main/java/jupgo/jupgoserver/service/JwtService.java
+++ b/src/main/java/jupgo/jupgoserver/service/JwtService.java
@@ -1,0 +1,120 @@
+package jupgo.jupgoserver.service;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTCreator;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTCreationException;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.Calendar;
+import java.util.Date;
+
+import static com.auth0.jwt.JWT.require;
+
+@Slf4j
+@Service
+public class JwtService {
+
+    @Value("${JWT.ISSUER}")
+    private String ISSUER;
+
+    @Value("${JWT.SECRET}")
+    private String SECRET;
+
+    /**
+     * 토큰 생성
+     */
+    public String create(final long user_id) {
+        try {
+            //토큰 생성 빌더 객체 생성
+            JWTCreator.Builder b = JWT.create();
+            //토큰 생성자 명시
+            b.withIssuer(ISSUER);
+            //토큰 payload 작성, key - value 형식, 객체도 가능
+            b.withClaim("user_id", user_id);
+
+            b.withExpiresAt(expiresAt());
+            //토큰 해싱해서 반환
+            return b.sign(Algorithm.HMAC256(SECRET));
+        } catch (JWTCreationException JwtCreationException) {
+            log.info(JwtCreationException.getMessage());
+        }
+        return null;
+    }
+
+    private Date expiresAt() {
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(new Date());
+        //한달 24*31
+        cal.add(Calendar.HOUR, 744);
+        return cal.getTime();
+    }
+
+    /**
+     * 토큰 해독
+     */
+    public Token decode(final String token) {
+        try {
+            //토큰 해독 객체 생성
+            final JWTVerifier jwtVerifier = require(Algorithm.HMAC256(SECRET)).withIssuer(ISSUER).build();
+            //토큰 검증
+            DecodedJWT decodedJWT = jwtVerifier.verify(token);
+            //토큰 payload 반환, 정상적인 토큰이라면 토큰 주인(사용자) 고유 ID, 아니라면 -1
+            return new Token(decodedJWT.getClaim("user_id").asLong().intValue());
+        } catch (JWTVerificationException jve) {
+            log.error(jve.getMessage());
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        }
+        return new Token();
+    }
+
+    public static class Token {
+        //토큰에 담길 정보 필드
+        //초기값을 -1로 설정함으로써 로그인 실패시 -1반환
+        private long user_id = -1;
+
+        public Token() {
+        }
+
+        public Token(final long user_id) {
+            this.user_id = user_id;
+        }
+
+        public long getUser_id() {
+            return user_id;
+        }
+    }
+
+    //반환될 토큰Res
+    @Data
+    public static class TokenRes {
+        //실제 토큰
+        private String token;
+        //userId 반환
+        private long userId;
+
+        public TokenRes() {
+        }
+
+        public TokenRes(final String token) {
+            this.token = token;
+        }
+
+        public TokenRes(final String token, final long userId) {
+            this.token = token;
+            this.userId = userId;
+        }
+    }
+
+    // 권환 확인
+    public boolean checkAuth(final String header, final long userId) {
+        return decode(header).getUser_id() == userId;
+    }
+}

--- a/src/main/java/jupgo/jupgoserver/service/KakaoService.java
+++ b/src/main/java/jupgo/jupgoserver/service/KakaoService.java
@@ -7,6 +7,7 @@ import org.apache.http.NameValuePair;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicNameValuePair;
@@ -19,21 +20,22 @@ import java.util.List;
 
 @Service
 public class KakaoService { //카카오톡 정보 반환
-    public JsonNode verifyAccessToken(String accessToken){
-        final String RequestUrl = "https://kapi.kakao.com/v2/user/me";
+    public String verifyAccessToken(String code){
+        final String RequestUrl = "https://kauth.kakao.com/oauth/token";
 
         final List<NameValuePair> postParams = new ArrayList<>();
 
         postParams.add(new BasicNameValuePair("grant_type", "authorization_code"));
-        postParams.add(new BasicNameValuePair("client_id", "0e2eea592596da82b9942824283c7046"));    // REST API KEY
+        postParams.add(new BasicNameValuePair("client_id", "035e5071402fccee6afb998ae1b5ea62"));    // REST API KEY
         postParams.add(new BasicNameValuePair("redirect_uri", "http://localhost:8080/api/user/login"));    // 리다이렉트 URI
-        postParams.add(new BasicNameValuePair("code", accessToken));    // 로그인 과정중 얻은 code 값
+        postParams.add(new BasicNameValuePair("code", code));    // 로그인 과정중 얻은 code 값
 
         final HttpClient client = HttpClientBuilder.create().build();
         final HttpPost post = new HttpPost(RequestUrl);
         // add header
-        post.addHeader("Authorization", "Bearer " + accessToken);
+        post.addHeader("Authorization", "Bearer " + code);
         JsonNode returnNode = null;
+        String accessToken = "";
         try {
 
             post.setEntity(new UrlEncodedFormEntity(postParams));
@@ -41,10 +43,39 @@ public class KakaoService { //카카오톡 정보 반환
             final int responseCode = response.getStatusLine().getStatusCode();
             System.out.println("\nSending 'POST' request to URL : " + RequestUrl);
             System.out.println("Response Code : " + responseCode);
+
             //JSON 형태 반환값 처리
             ObjectMapper mapper = new ObjectMapper();
             returnNode = mapper.readTree(response.getEntity().getContent());
+            accessToken = returnNode.path("access_token").asText();
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        } catch (ClientProtocolException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            // clear resources
+        }
+        return accessToken;
+    }
 
+    public JsonNode getUserInfo(String accessToken) {
+        final String RequestUrl = "https://kapi.kakao.com/v2/user/me";
+        final HttpClient client = HttpClientBuilder.create().build();
+        final HttpGet get = new HttpGet(RequestUrl);
+        // add header
+        get.addHeader("Authorization", "Bearer " + accessToken);
+        JsonNode returnNode = null;
+        try {
+            final HttpResponse response = client.execute(get);
+            final int responseCode = response.getStatusLine().getStatusCode();
+            System.out.println("\nSending 'GET' request to URL : " + RequestUrl);
+            System.out.println("Response Code : " + responseCode);
+
+            //JSON 형태 반환값 처리
+            ObjectMapper mapper = new ObjectMapper();
+            returnNode = mapper.readTree(response.getEntity().getContent());
         } catch (UnsupportedEncodingException e) {
             e.printStackTrace();
         } catch (ClientProtocolException e) {

--- a/src/main/java/jupgo/jupgoserver/service/KakaoService.java
+++ b/src/main/java/jupgo/jupgoserver/service/KakaoService.java
@@ -1,0 +1,59 @@
+package jupgo.jupgoserver.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicNameValuePair;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class KakaoService { //카카오톡 정보 반환
+    public JsonNode verifyAccessToken(String accessToken){
+        final String RequestUrl = "https://kapi.kakao.com/v2/user/me";
+
+        final List<NameValuePair> postParams = new ArrayList<>();
+
+        postParams.add(new BasicNameValuePair("grant_type", "authorization_code"));
+        postParams.add(new BasicNameValuePair("client_id", "0e2eea592596da82b9942824283c7046"));    // REST API KEY
+        postParams.add(new BasicNameValuePair("redirect_uri", "http://localhost:8080/api/user/login"));    // 리다이렉트 URI
+        postParams.add(new BasicNameValuePair("code", accessToken));    // 로그인 과정중 얻은 code 값
+
+        final HttpClient client = HttpClientBuilder.create().build();
+        final HttpPost post = new HttpPost(RequestUrl);
+        // add header
+        post.addHeader("Authorization", "Bearer " + accessToken);
+        JsonNode returnNode = null;
+        try {
+
+            post.setEntity(new UrlEncodedFormEntity(postParams));
+            final HttpResponse response = client.execute(post);
+            final int responseCode = response.getStatusLine().getStatusCode();
+            System.out.println("\nSending 'POST' request to URL : " + RequestUrl);
+            System.out.println("Response Code : " + responseCode);
+            //JSON 형태 반환값 처리
+            ObjectMapper mapper = new ObjectMapper();
+            returnNode = mapper.readTree(response.getEntity().getContent());
+
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        } catch (ClientProtocolException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            // clear resources
+        }
+        return returnNode;
+    }
+}

--- a/src/main/java/jupgo/jupgoserver/service/UserService.java
+++ b/src/main/java/jupgo/jupgoserver/service/UserService.java
@@ -1,130 +1,34 @@
 package jupgo.jupgoserver.service;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
+
 import jupgo.jupgoserver.domain.user.User;
+import jupgo.jupgoserver.dto.user.SaveUserRequestDto;
+import jupgo.jupgoserver.dto.user.SaveUserResponseDto;
 import jupgo.jupgoserver.repository.UserRepository;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.io.*;
-import java.net.HttpURLConnection;
-import java.net.URL;
 
 @Service
-@Transactional
 public class UserService {
 
+
     private UserRepository userRepository;
+    public UserService(UserRepository userRepository) { this.userRepository = userRepository; }
 
-    public UserService(UserRepository userRepository) {
-        this.userRepository = userRepository;
+    public boolean existsByKakaoUserId(Integer kakaoUserId) {
+        User user = userRepository.findByKakaoUserId(kakaoUserId);
+        if (user == null)
+            return false;
+        else
+            return true;
     }
 
-    public String getKaKaoAccessToken(String code) throws IOException{
-        String access_Token="";
-        String refresh_Token ="";
-        String reqURL = "https://kauth.kakao.com/oauth/token";
-
-        try{
-            URL url = new URL(reqURL);
-            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-
-            //POST 요청을 위해 기본값이 false인 setDoOutput을 true로
-            conn.setRequestMethod("POST");
-            conn.setDoOutput(true);
-
-            //POST 요청에 필요로 요구하는 파라미터 스트림을 통해 전송
-            BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(conn.getOutputStream()));
-            StringBuilder sb = new StringBuilder();
-            sb.append("grant_type=authorization_code");
-            sb.append("&client_id=0e2eea592596da82b9942824283c7046"); // TODO REST_API_KEY 입력
-            sb.append("&redirect_uri=http://localhost:8080/api/user/login"); // TODO 인가코드 받은 redirect_uri 입력
-            sb.append("&code=" + code);
-            bw.write(sb.toString());
-            bw.flush();
-
-            //결과 코드가 200이라면 성공
-            int responseCode = conn.getResponseCode();
-            System.out.println("responseCode : " + responseCode);
-            BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
-            String line = "";
-            String result = "";
-
-            while ((line = br.readLine()) != null) {
-                result += line;
-            }
-            System.out.println("response body : " + result);
-
-            JsonParser parser = new JsonParser();
-            JsonElement element = parser.parse(result);
-
-            access_Token = element.getAsJsonObject().get("access_token").getAsString();
-            refresh_Token = element.getAsJsonObject().get("refresh_token").getAsString();
-
-            System.out.println("access_token : " + access_Token);
-            System.out.println("refresh_token : " + refresh_Token);
-
-            br.close();
-            bw.close();
-        }catch (IOException e) {
-            e.printStackTrace();
+    public SaveUserResponseDto save(SaveUserRequestDto saveUserRequestDto) {
+        if(saveUserRequestDto.getEmail()==null){
+            saveUserRequestDto.setEmail("");
         }
-
-        return access_Token;
-    }
-
-    public User createKakaoUser(String token) throws IOException {
-        String reqURL = "https://kapi.kakao.com/v2/user/me";
-        User user = new User();
-
-        //access_token을 이용하여 사용자 정보 조회
-        try {
-            URL url = new URL(reqURL);
-            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-
-            conn.setRequestMethod("POST");
-            conn.setDoOutput(true);
-            conn.setRequestProperty("Authorization", "Bearer " + token); //전송할 header 작성, access_token전송
-
-            //결과 코드가 200이라면 성공
-            int responseCode = conn.getResponseCode();
-            System.out.println("responseCode : " + responseCode);
-
-            //요청을 통해 얻은 JSON타입의 Response 메세지 읽어오기
-            BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
-            String line = "";
-            String result = "";
-
-            while ((line = br.readLine()) != null) {
-                result += line;
-            }
-            System.out.println("response body : " + result);
-            br.close();
-
-            JsonParser parser = new JsonParser();
-            JsonElement element = parser.parse(result);
-
-            JsonObject properties = element.getAsJsonObject().get("properties").getAsJsonObject();
-            JsonObject kakao_account = element.getAsJsonObject().get("kakao_account").getAsJsonObject();
-
-            String nickname = properties.getAsJsonObject().get("nickname").getAsString();
-//            String email = kakao_account.getAsJsonObject().get("email").getAsString(); // TODO 활성화하기
-
-            user.setNickname(nickname);
-//            user.setEmail(email);
-            user.setEmail("test@test.test"); // TODO 위엣 라인과 교체하기
-
-//            if (userRepository.findByEmail(email).isEmpty()) {
-//                userRepository.save(user);
-//            }
-            userRepository.save(user); // TODO 위엣 if문과 교체하기
-
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-
-        return user;
+        User user = new User(saveUserRequestDto);
+        userRepository.save(user);
+        return new SaveUserResponseDto(user);
     }
 }

--- a/src/main/java/jupgo/jupgoserver/service/UserService.java
+++ b/src/main/java/jupgo/jupgoserver/service/UserService.java
@@ -2,7 +2,6 @@ package jupgo.jupgoserver.service;
 
 
 import jupgo.jupgoserver.domain.user.User;
-import jupgo.jupgoserver.dto.user.SaveUserRequestDto;
 import jupgo.jupgoserver.dto.user.SaveUserResponseDto;
 import jupgo.jupgoserver.repository.UserRepository;
 import org.springframework.stereotype.Service;
@@ -10,24 +9,13 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class UserService {
-
-
     private UserRepository userRepository;
     public UserService(UserRepository userRepository) { this.userRepository = userRepository; }
 
-    public boolean existsByKakaoUserId(Integer kakaoUserId) {
-        User user = userRepository.findByKakaoUserId(kakaoUserId);
-        if (user == null)
-            return false;
-        else
-            return true;
-    }
-
-    public SaveUserResponseDto save(SaveUserRequestDto saveUserRequestDto) {
-        if(saveUserRequestDto.getEmail()==null){
-            saveUserRequestDto.setEmail("");
+    public SaveUserResponseDto save(User user) {
+        if(user.getEmail()==null){
+            user.setEmail("");
         }
-        User user = new User(saveUserRequestDto);
         userRepository.save(user);
         return new SaveUserResponseDto(user);
     }

--- a/src/main/java/jupgo/jupgoserver/util/response/Response.java
+++ b/src/main/java/jupgo/jupgoserver/util/response/Response.java
@@ -1,11 +1,17 @@
 package jupgo.jupgoserver.util.response;
 
-public class SuccessResponse<T> {
+public class Response<T> {
     private int statusCode;
     private String message;
     private T data;
 
-    public SuccessResponse(int statusCode, String message, T data) {
+    public Response(int statusCode, String message) {
+        this.statusCode = statusCode;
+        this.message = message;
+        this.data = null;
+    }
+
+    public Response(int statusCode, String message, T data) {
         this.statusCode = statusCode;
         this.message = message;
         this.data = data;

--- a/src/main/java/jupgo/jupgoserver/util/response/StatusCode.java
+++ b/src/main/java/jupgo/jupgoserver/util/response/StatusCode.java
@@ -2,7 +2,11 @@ package jupgo.jupgoserver.util.response;
 
 public enum StatusCode {
     OK(200),
-    CREATED(201);
+    CREATED(201),
+    BAD_REQUEST(400),
+    NOT_FOUND(404),
+    INTERNAL_ERROR(500);
+
 
     private final int code;
 

--- a/src/main/java/jupgo/jupgoserver/util/response/StatusMessage.java
+++ b/src/main/java/jupgo/jupgoserver/util/response/StatusMessage.java
@@ -3,7 +3,12 @@ package jupgo.jupgoserver.util.response;
 public enum StatusMessage {
 
     // Diary
-    PLOGGING_SAVE_SUCCESS("플로깅 기록 저장 성공");
+    PLOGGING_SAVE_SUCCESS("플로깅 기록 저장 성공"),
+    SIGNUP_SUCCESS("회원가입 성공"),
+    LOGIN_SUCCESS("로그인 성공"),
+
+    LOGIN_FAIL("로그인 실패"),
+    INTERNAL_ERROR("서버 에러");
 
     private final String message;
 


### PR DESCRIPTION
## 변경
- login, signup 로직 뜯어고치기
  - login 했을 때, 유저 정보가 DB에 없으면 회원가입이 되도록 구현
- jwt 토큰 발급 로직 추가
  - jwt에 유저 ID payload 추가
  - jwt에 담긴 유저 ID를 얻고싶다면, Token클래스의 decode를 사용하면 됩니다 @beer-2000 
## 테스트
- 회원가입 & 로그인 후 DB에 저장되는 것 확인
