### PR TITLE
[Feat] Diary 저장 및 조회

### DIFF
--- a/src/main/java/jupgo/jupgoserver/JupgoServerApplication.java
+++ b/src/main/java/jupgo/jupgoserver/JupgoServerApplication.java
@@ -9,5 +9,4 @@ public class JupgoServerApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(JupgoServerApplication.class, args);
 	}
-
 }

--- a/src/main/java/jupgo/jupgoserver/controller/DiaryController.java
+++ b/src/main/java/jupgo/jupgoserver/controller/DiaryController.java
@@ -6,32 +6,57 @@ import static jupgo.jupgoserver.util.response.StatusMessage.*;
 import jupgo.jupgoserver.dto.diary.SaveDiaryRequestDto;
 import jupgo.jupgoserver.dto.diary.SaveDiaryResponseDto;
 import jupgo.jupgoserver.service.DiaryService;
+import jupgo.jupgoserver.service.JwtService;
 import jupgo.jupgoserver.service.S3Service;
+import jupgo.jupgoserver.service.UserService;
 import jupgo.jupgoserver.util.response.Response;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.multipart.MultipartFile;
 
+@Controller
 @RequestMapping("/api/diary")
 public class DiaryController {
     @Autowired
     private DiaryService diaryService;
     @Autowired
     private S3Service s3Service;
+    @Autowired
+    private JwtService jwtService;
+    @Autowired
+    private UserService userService;
 
     @ResponseBody
     @PostMapping()
     public Response saveDiary(
             @RequestPart("diaryData") SaveDiaryRequestDto saveDiaryRequestDto,
-            @RequestParam("file") MultipartFile file)
+            @RequestParam("file") MultipartFile file,
+            @RequestHeader("Authorization") String authorizationHeader)
             throws Exception {
+        long userId = jwtService.decode(authorizationHeader.split(" ")[1]).getUser_id();
+        long treeId = userService.getCurrentTreeIdByUserId(userId);
+        System.out.println(treeId);
         String fileLink = s3Service.getLinkAfterSaveUploadFile(file);
         saveDiaryRequestDto.setPhoto(fileLink);
         SaveDiaryResponseDto saveDiaryResponseDto = diaryService.saveDiary(saveDiaryRequestDto);
         return new Response(OK.getCode(), PLOGGING_SAVE_SUCCESS.getMessage(), saveDiaryResponseDto);
+    }
+
+    @ResponseBody
+    @GetMapping("/test2")
+    public Response diaryTest2(@RequestHeader("Authorization") String authorizationHeader) {
+        System.out.println(authorizationHeader);
+        String[] tokenArray = authorizationHeader.split(" ");
+        String token = tokenArray[1];
+        System.out.println(token);
+        System.out.println(jwtService.decode(token));
+        return new Response(OK.getCode(), PLOGGING_SAVE_SUCCESS.getMessage(), "hi");
     }
 }

--- a/src/main/java/jupgo/jupgoserver/controller/DiaryController.java
+++ b/src/main/java/jupgo/jupgoserver/controller/DiaryController.java
@@ -3,6 +3,7 @@ package jupgo.jupgoserver.controller;
 import static jupgo.jupgoserver.util.response.StatusCode.OK;
 import static jupgo.jupgoserver.util.response.StatusMessage.*;
 
+import jupgo.jupgoserver.domain.tree.Tree;
 import jupgo.jupgoserver.dto.diary.SaveDiaryRequestDto;
 import jupgo.jupgoserver.dto.diary.SaveDiaryResponseDto;
 import jupgo.jupgoserver.service.DiaryService;
@@ -47,9 +48,12 @@ public class DiaryController {
         long treeId = userService.getCurrentTreeIdByUserId(userId);
         if (treeId == -1) {
             treeService.saveTreeInUser(userId);
+            treeId = userService.getCurrentTreeIdByUserId(userId);
         }
+        Tree tree = treeService.getTreeById(treeId);
         String fileLink = s3Service.getLinkAfterSaveUploadFile(file);
         saveDiaryRequestDto.setPhoto(fileLink);
+        saveDiaryRequestDto.setTree(tree);
         SaveDiaryResponseDto saveDiaryResponseDto = diaryService.saveDiary(saveDiaryRequestDto);
         return new Response(OK.getCode(), PLOGGING_SAVE_SUCCESS.getMessage(), saveDiaryResponseDto);
     }

--- a/src/main/java/jupgo/jupgoserver/controller/DiaryController.java
+++ b/src/main/java/jupgo/jupgoserver/controller/DiaryController.java
@@ -8,6 +8,7 @@ import jupgo.jupgoserver.dto.diary.SaveDiaryResponseDto;
 import jupgo.jupgoserver.service.DiaryService;
 import jupgo.jupgoserver.service.JwtService;
 import jupgo.jupgoserver.service.S3Service;
+import jupgo.jupgoserver.service.TreeService;
 import jupgo.jupgoserver.service.UserService;
 import jupgo.jupgoserver.util.response.Response;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,6 +33,8 @@ public class DiaryController {
     private JwtService jwtService;
     @Autowired
     private UserService userService;
+    @Autowired
+    private TreeService treeService;
 
     @ResponseBody
     @PostMapping()
@@ -42,7 +45,9 @@ public class DiaryController {
             throws Exception {
         long userId = jwtService.decode(authorizationHeader.split(" ")[1]).getUser_id();
         long treeId = userService.getCurrentTreeIdByUserId(userId);
-        System.out.println(treeId);
+        if (treeId == -1) {
+            treeService.saveTreeInUser(userId);
+        }
         String fileLink = s3Service.getLinkAfterSaveUploadFile(file);
         saveDiaryRequestDto.setPhoto(fileLink);
         SaveDiaryResponseDto saveDiaryResponseDto = diaryService.saveDiary(saveDiaryRequestDto);

--- a/src/main/java/jupgo/jupgoserver/controller/DiaryController.java
+++ b/src/main/java/jupgo/jupgoserver/controller/DiaryController.java
@@ -6,6 +6,7 @@ import static jupgo.jupgoserver.util.response.StatusCode.UNAUTHORIZED;
 import static jupgo.jupgoserver.util.response.StatusMessage.*;
 
 import com.auth0.jwt.exceptions.JWTVerificationException;
+import java.util.List;
 import jupgo.jupgoserver.domain.tree.Tree;
 import jupgo.jupgoserver.dto.diary.SaveDiaryRequestDto;
 import jupgo.jupgoserver.dto.diary.SaveDiaryResponseDto;
@@ -80,6 +81,15 @@ public class DiaryController {
     public Response getDiariesOfTree(@PathVariable("treeId") Long treeId){
         ReturnTreeContainDiariesDto returnTreeContainDiariesDto = treeService.getDiariesByTreeId(treeId);
         return new Response(OK.getCode(), GET_DIARIES_OF_TREE_SUCCESS.getMessage(), returnTreeContainDiariesDto);
+    }
+
+    @ResponseBody
+    @GetMapping("/all")
+    public Response getDiariesOfAllTrees(@RequestHeader("Authorization") String authorizationHeader){
+        long userId = jwtService.decode(authorizationHeader.split(" ")[1]).getUser_id();
+        List<Tree> trees = userService.getTreesByUserId(userId);
+        List<ReturnTreeContainDiariesDto> returnTreeContainDiariesDtos = treeService.getAllDiariesByTrees(trees);
+        return new Response(OK.getCode(), GET_ALL_DIARIES.getMessage(), returnTreeContainDiariesDtos);
     }
 
     @ResponseBody

--- a/src/main/java/jupgo/jupgoserver/controller/DiaryController.java
+++ b/src/main/java/jupgo/jupgoserver/controller/DiaryController.java
@@ -9,6 +9,7 @@ import com.auth0.jwt.exceptions.JWTVerificationException;
 import jupgo.jupgoserver.domain.tree.Tree;
 import jupgo.jupgoserver.dto.diary.SaveDiaryRequestDto;
 import jupgo.jupgoserver.dto.diary.SaveDiaryResponseDto;
+import jupgo.jupgoserver.dto.tree.ReturnTreeContainDiariesDto;
 import jupgo.jupgoserver.service.DiaryService;
 import jupgo.jupgoserver.service.JwtService;
 import jupgo.jupgoserver.service.S3Service;
@@ -20,6 +21,7 @@ import jupgo.jupgoserver.util.response.StatusMessage;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -71,6 +73,13 @@ public class DiaryController {
             System.out.println(e);
             return new Response(INTERNAL_ERROR.getCode(), StatusMessage.INTERNAL_ERROR.getMessage());
         }
+    }
+
+    @ResponseBody
+    @GetMapping("/{treeId}")
+    public Response getDiariesOfTree(@PathVariable("treeId") Long treeId){
+        ReturnTreeContainDiariesDto returnTreeContainDiariesDto = treeService.getDiariesByTreeId(treeId);
+        return new Response(OK.getCode(), GET_DIARIES_OF_TREE_SUCCESS.getMessage(), returnTreeContainDiariesDto);
     }
 
     @ResponseBody

--- a/src/main/java/jupgo/jupgoserver/domain/diary/Diary.java
+++ b/src/main/java/jupgo/jupgoserver/domain/diary/Diary.java
@@ -33,6 +33,7 @@ public class Diary {
         this.distance = saveDiaryRequestDto.getDistance();
         this.duration = saveDiaryRequestDto.getDuration();
         this.photo = saveDiaryRequestDto.getPhoto();
+        this.tree = saveDiaryRequestDto.getTree();
     }
 
     public Diary() {

--- a/src/main/java/jupgo/jupgoserver/domain/tree/ExperienceManager.java
+++ b/src/main/java/jupgo/jupgoserver/domain/tree/ExperienceManager.java
@@ -1,0 +1,43 @@
+package jupgo.jupgoserver.domain.tree;
+
+import java.util.Map;
+
+public class ExperienceManager {
+    private static final Map<Integer, Integer> LEVEL_TABLE = Map.of(
+            1, 11_000,
+            2, 14_500,
+            3, 19_500,
+            4, 24_000,
+            5, 31_000
+    );
+
+    public static void addExperience(Tree tree, int experience) {
+        int experienceToConvert = 0;
+        int level = tree.getLevel();
+        int percentage = tree.getPercentage();
+        int percentageToAdd = convertExperienceToPercentage(level, experience);
+        percentage += percentageToAdd;
+
+        while (percentage >= 100) {
+            experienceToConvert = convertPercentageToExperience(level, percentage - 100);
+            percentage = 0;
+            level += 1;
+            if (level == 6) {
+                break;
+            }
+            percentageToAdd = convertExperienceToPercentage(level, experienceToConvert);
+            percentage += percentageToAdd;
+        }
+
+        tree.setLevel(level);
+        tree.setPercentage(percentage);
+    }
+
+    private static int convertPercentageToExperience(int level, int percentage) {
+        return percentage * LEVEL_TABLE.get(level) / 100;
+    }
+
+    private static int convertExperienceToPercentage(int beforeLevel, int experience) {
+        return experience * 100 / LEVEL_TABLE.get(beforeLevel);
+    }
+}

--- a/src/main/java/jupgo/jupgoserver/domain/tree/Tree.java
+++ b/src/main/java/jupgo/jupgoserver/domain/tree/Tree.java
@@ -1,5 +1,6 @@
 package jupgo.jupgoserver.domain.tree;
 
+import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.*;
 import jupgo.jupgoserver.domain.diary.Diary;
@@ -27,12 +28,21 @@ public class Tree {
     @OneToMany(mappedBy = "tree")
     private List<Diary> diaries;
 
-    public Long getId() {
-        return id;
+    public Tree(User user) {
+        this.user = user;
+        this.name = TreeType.generateName();
+        this.sort = TreeType.generateSort();
+        this.level = 0;
+        this.percentage = 0;
+        this.diaries = new ArrayList<>();
     }
 
-    public void setId(Long id) {
-        this.id = id;
+    public Tree() {
+
+    }
+
+    public Long getId() {
+        return id;
     }
 
     public String getName() {
@@ -43,7 +53,19 @@ public class Tree {
         return percentage;
     }
 
-    public void setPercentage(Integer percentage) {
-        this.percentage = percentage;
+    public String getSort() {
+        return sort;
+    }
+
+    public Integer getLevel() {
+        return level;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public List<Diary> getDiaries() {
+        return diaries;
     }
 }

--- a/src/main/java/jupgo/jupgoserver/domain/tree/Tree.java
+++ b/src/main/java/jupgo/jupgoserver/domain/tree/Tree.java
@@ -1,5 +1,6 @@
 package jupgo.jupgoserver.domain.tree;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.*;
@@ -32,12 +33,31 @@ public class Tree {
         this.user = user;
         this.name = TreeType.generateName();
         this.sort = TreeType.generateSort();
-        this.level = 0;
+        this.level = 1;
         this.percentage = 0;
         this.diaries = new ArrayList<>();
     }
 
     public Tree() {
+        this.name = TreeType.generateName();
+        this.sort = TreeType.generateSort();
+        this.level = 1;
+        this.percentage = 0;
+        this.diaries = new ArrayList<>();
+    }
+
+    public void addExperience(int distance, Duration duration) {
+        int experienceOfDistance = convertDistanceToExperience(distance);
+        int experienceOfDuration = convertDistanceToExperience(duration);
+        ExperienceManager.addExperience(this, experienceOfDistance + experienceOfDuration);
+    }
+
+    private int convertDistanceToExperience(int distance) {
+        return distance;
+    }
+
+    private int convertDistanceToExperience(Duration duration) {
+        return (int) (duration.getSeconds() / 60) * 100;
 
     }
 
@@ -53,12 +73,20 @@ public class Tree {
         return percentage;
     }
 
+    public void setPercentage(Integer percentage) {
+        this.percentage = percentage;
+    }
+
     public String getSort() {
         return sort;
     }
 
     public Integer getLevel() {
         return level;
+    }
+
+    public void setLevel(Integer level) {
+        this.level = level;
     }
 
     public User getUser() {

--- a/src/main/java/jupgo/jupgoserver/domain/tree/TreeType.java
+++ b/src/main/java/jupgo/jupgoserver/domain/tree/TreeType.java
@@ -1,11 +1,22 @@
 package jupgo.jupgoserver.domain.tree;
 
 import java.util.List;
+import java.util.Random;
 
 public class TreeType {
-    private final List<String> NAMES = List.of("열정나무", "스피드나무", "러닝나무", "초록나무", "이삭나무", "에코나무", "탄소나무", "산소나무",
+    private static final List<String> NAMES = List.of("열정나무", "스피드나무", "러닝나무", "초록나무", "이삭나무", "에코나무", "탄소나무", "산소나무",
             "청정나무", "뿌듯나무", "무럭나무", "성장나무", "기쁨나무", "달려나무", "행복나무", "최고나무", "희망나무", "너랑나무", "줍줍나무", "노래나무", "미소나무",
             "웃음나무", "건강나무", "튼튼나무", "꿈꾸는나무", "에너지나무", "나무나무", "쑥쑥나무", "활짝나무", "힘쎈나무");
-    private final List<String> SORTS = List.of("first", "second");
-    private final List<Integer> LEVELS = List.of(0, 1, 2, 3, 4, 5);
+    private static final List<String> SORTS = List.of("first", "second");
+    private static final List<Integer> LEVELS = List.of(0, 1, 2, 3, 4, 5);
+
+    public static String generateName() {
+        Random random = new Random();
+        return NAMES.get(random.nextInt(NAMES.size()));
+    }
+
+    public static String generateSort() {
+        Random random = new Random();
+        return SORTS.get(random.nextInt(SORTS.size()));
+    }
 }

--- a/src/main/java/jupgo/jupgoserver/domain/user/User.java
+++ b/src/main/java/jupgo/jupgoserver/domain/user/User.java
@@ -19,7 +19,6 @@ public class User {
     private String email;
     private Integer kakaoId;
 
-
     @OneToMany(mappedBy = "user")
     private List<Tree> trees;
 
@@ -62,5 +61,9 @@ public class User {
 
     public void setKakaoId(Integer kakaoId) {
         this.kakaoId = kakaoId;
+    }
+
+    public List<Tree> getTrees() {
+        return trees;
     }
 }

--- a/src/main/java/jupgo/jupgoserver/domain/user/User.java
+++ b/src/main/java/jupgo/jupgoserver/domain/user/User.java
@@ -17,7 +17,7 @@ public class User {
     private Long id;
     private String nickname;
     private String email;
-    private Long kakaoId;
+    private String kakaoId;
 
     @OneToMany(mappedBy = "user")
     private List<Tree> trees;
@@ -55,11 +55,11 @@ public class User {
         this.email = email;
     }
 
-    public Long getKakaoId() {
+    public String getKakaoId() {
         return kakaoId;
     }
 
-    public void setKakaoId(Long kakaoId) {
+    public void setKakaoId(String kakaoId) {
         this.kakaoId = kakaoId;
     }
 

--- a/src/main/java/jupgo/jupgoserver/dto/diary/ReturnDiaryDto.java
+++ b/src/main/java/jupgo/jupgoserver/dto/diary/ReturnDiaryDto.java
@@ -1,0 +1,47 @@
+package jupgo.jupgoserver.dto.diary;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import jupgo.jupgoserver.domain.diary.Diary;
+
+public class ReturnDiaryDto {
+    private long id;
+    private LocalDate date;
+    private String location;
+    private int distance;
+    private Duration duration;
+    private String photo;
+
+    public ReturnDiaryDto(Diary diary) {
+        this.id = diary.getId();
+        this.date = diary.getDate();
+        this.location = diary.getLocation();
+        this.distance = diary.getDistance();
+        this.duration = diary.getDuration();
+        this.photo = diary.getPhoto();
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public int getDistance() {
+        return distance;
+    }
+
+    public Duration getDuration() {
+        return duration;
+    }
+
+    public String getPhoto() {
+        return photo;
+    }
+}

--- a/src/main/java/jupgo/jupgoserver/dto/diary/SaveDiaryRequestDto.java
+++ b/src/main/java/jupgo/jupgoserver/dto/diary/SaveDiaryRequestDto.java
@@ -8,6 +8,7 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Date;
+import jupgo.jupgoserver.domain.tree.Tree;
 
 public class SaveDiaryRequestDto {
     private LocalDate date;
@@ -15,6 +16,16 @@ public class SaveDiaryRequestDto {
     private int distance;
     private Duration duration;
     private String photo;
+
+    public Tree getTree() {
+        return tree;
+    }
+
+    public void setTree(Tree tree) {
+        this.tree = tree;
+    }
+
+    private Tree tree;
 
     public LocalDate getDate() {
         return date;

--- a/src/main/java/jupgo/jupgoserver/dto/tree/ReturnTreeContainDiariesDto.java
+++ b/src/main/java/jupgo/jupgoserver/dto/tree/ReturnTreeContainDiariesDto.java
@@ -1,0 +1,32 @@
+package jupgo.jupgoserver.dto.tree;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import jupgo.jupgoserver.domain.tree.Tree;
+import jupgo.jupgoserver.dto.diary.ReturnDiaryDto;
+
+public class ReturnTreeContainDiariesDto {
+    private long id;
+    private String name;
+    private List<ReturnDiaryDto> diaries;
+
+    public ReturnTreeContainDiariesDto(Tree tree) {
+        this.id = tree.getId();
+        this.name = tree.getName();
+        this.diaries = tree.getDiaries().stream()
+                .map(ReturnDiaryDto::new)
+                .collect(Collectors.toList());
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public List<ReturnDiaryDto> getDiaries() {
+        return diaries;
+    }
+}

--- a/src/main/java/jupgo/jupgoserver/dto/user/SaveUserRequestDto.java
+++ b/src/main/java/jupgo/jupgoserver/dto/user/SaveUserRequestDto.java
@@ -8,7 +8,7 @@ public class SaveUserRequestDto {
     private String nickname;
 
     private String email;
-    private Long     kakaoId;
+    private String kakaoId;
 
     private String code;
 

--- a/src/main/java/jupgo/jupgoserver/repository/TreeRepository.java
+++ b/src/main/java/jupgo/jupgoserver/repository/TreeRepository.java
@@ -1,0 +1,19 @@
+package jupgo.jupgoserver.repository;
+
+import javax.persistence.EntityManager;
+import jupgo.jupgoserver.domain.tree.Tree;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class TreeRepository {
+    private final EntityManager em;
+
+    public TreeRepository(EntityManager em) {
+        this.em = em;
+    }
+
+    public Tree save(Tree tree) {
+        em.persist(tree);
+        return tree;
+    }
+}

--- a/src/main/java/jupgo/jupgoserver/repository/TreeRepository.java
+++ b/src/main/java/jupgo/jupgoserver/repository/TreeRepository.java
@@ -12,8 +12,13 @@ public class TreeRepository {
         this.em = em;
     }
 
-    public Tree save(Tree tree) {
+    public void save(Tree tree) {
         em.persist(tree);
-        return tree;
+    }
+
+    public Tree findById(long treeId) {
+        return em.createQuery("select tree from Tree tree where tree.id = :treeId", Tree.class)
+                .setParameter("treeId", treeId)
+                .getSingleResult();
     }
 }

--- a/src/main/java/jupgo/jupgoserver/repository/UserRepository.java
+++ b/src/main/java/jupgo/jupgoserver/repository/UserRepository.java
@@ -20,7 +20,7 @@ public class UserRepository {
         return user;
     }
 
-    public List<User> findByKakaoUserId(Long kakaoUserId) {
+    public List<User> findByKakaoUserId(String kakaoUserId) {
         List<User> result = em.createQuery("select u from User u where u.kakaoId = :kakaoUserId", User.class)
                 .setParameter("kakaoUserId", kakaoUserId)
                 .getResultList();

--- a/src/main/java/jupgo/jupgoserver/repository/UserRepository.java
+++ b/src/main/java/jupgo/jupgoserver/repository/UserRepository.java
@@ -27,4 +27,11 @@ public class UserRepository {
         return result;
     }
 
+    public User findById(long userId) {
+        List<User> users = em.createQuery("select u from User u where u.id = :userId", User.class)
+                .setParameter("userId", userId)
+                .getResultList();
+        return users.get(0);
+    }
+
 }

--- a/src/main/java/jupgo/jupgoserver/service/AuthService.java
+++ b/src/main/java/jupgo/jupgoserver/service/AuthService.java
@@ -32,12 +32,12 @@ public class AuthService {
     }
 
     public JwtService.TokenRes kakaoLogin(final String code) throws Exception {
-        long userKakaoId = -1;
+        String userKakaoId = "-1";
         String accessToken = kakaoService.verifyAccessToken(code);
         JsonNode userInfo = kakaoService.getUserInfo(accessToken);
 
         try {
-            userKakaoId = userInfo.path("id").asLong();
+            userKakaoId = userInfo.path("id").asText();
         }
         catch (Exception e) {
             throw new Exception();
@@ -52,7 +52,7 @@ public class AuthService {
         } else {
             User newUser = new User();
             String email = userInfo.path("kakao_account").path("email").asText();
-            newUser.setKakaoId(userInfo.path("id").longValue());
+            newUser.setKakaoId(userInfo.path("id").toString());
 
             JsonNode kakao_account = userInfo.path("kakao_account");
             if (kakao_account.path("has_email").asBoolean() && kakao_account.path("is_email_valid").asBoolean() && kakao_account.path("is_email_verified").asBoolean()) {

--- a/src/main/java/jupgo/jupgoserver/service/DiaryService.java
+++ b/src/main/java/jupgo/jupgoserver/service/DiaryService.java
@@ -11,7 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class DiaryService {
 
-    private DiaryRepository diaryRepository;
+    private final DiaryRepository diaryRepository;
 
     public DiaryService(DiaryRepository diaryRepository) {
         this.diaryRepository = diaryRepository;

--- a/src/main/java/jupgo/jupgoserver/service/JwtService.java
+++ b/src/main/java/jupgo/jupgoserver/service/JwtService.java
@@ -60,19 +60,12 @@ public class JwtService {
      * 토큰 해독
      */
     public Token decode(final String token) {
-        try {
-            //토큰 해독 객체 생성
-            final JWTVerifier jwtVerifier = require(Algorithm.HMAC256(SECRET)).withIssuer(ISSUER).build();
-            //토큰 검증
-            DecodedJWT decodedJWT = jwtVerifier.verify(token);
-            //토큰 payload 반환, 정상적인 토큰이라면 토큰 주인(사용자) 고유 ID, 아니라면 -1
-            return new Token(decodedJWT.getClaim("user_id").asLong().intValue());
-        } catch (JWTVerificationException jve) {
-            log.error(jve.getMessage());
-        } catch (Exception e) {
-            log.error(e.getMessage());
-        }
-        return new Token();
+        //토큰 해독 객체 생성
+        final JWTVerifier jwtVerifier = require(Algorithm.HMAC256(SECRET)).withIssuer(ISSUER).build();
+        //토큰 검증
+        DecodedJWT decodedJWT = jwtVerifier.verify(token);
+        //토큰 payload 반환, 정상적인 토큰이라면 토큰 주인(사용자) 고유 ID, 아니라면 -1
+        return new Token(decodedJWT.getClaim("user_id").asLong().intValue());
     }
 
     public static class Token {

--- a/src/main/java/jupgo/jupgoserver/service/TreeService.java
+++ b/src/main/java/jupgo/jupgoserver/service/TreeService.java
@@ -28,4 +28,8 @@ public class TreeService {
     private Tree createTree(User user) {
         return new Tree(user);
     }
+
+    public Tree getTreeById(long treeId) {
+        return treeRepository.findById(treeId);
+    }
 }

--- a/src/main/java/jupgo/jupgoserver/service/TreeService.java
+++ b/src/main/java/jupgo/jupgoserver/service/TreeService.java
@@ -3,6 +3,7 @@ package jupgo.jupgoserver.service;
 import java.time.Duration;
 import jupgo.jupgoserver.domain.tree.Tree;
 import jupgo.jupgoserver.domain.user.User;
+import jupgo.jupgoserver.dto.tree.ReturnTreeContainDiariesDto;
 import jupgo.jupgoserver.repository.TreeRepository;
 import jupgo.jupgoserver.repository.UserRepository;
 import org.springframework.stereotype.Service;
@@ -37,5 +38,9 @@ public class TreeService {
     public void addExperience(Tree tree, int distance, Duration duration) {
         tree.addExperience(distance, duration);
         treeRepository.save(tree);
+    }
+
+    public ReturnTreeContainDiariesDto getDiariesByTreeId(Long treeId) {
+        return new ReturnTreeContainDiariesDto(treeRepository.findById(treeId));
     }
 }

--- a/src/main/java/jupgo/jupgoserver/service/TreeService.java
+++ b/src/main/java/jupgo/jupgoserver/service/TreeService.java
@@ -1,19 +1,31 @@
-//package jupgo.jupgoserver.service;
-//
-//import org.springframework.stereotype.Service;
-//import org.springframework.transaction.annotation.Transactional;
-//
-//@Service
-//@Transactional
-//public class TreeService {
-//
-//    private TreeRepository treeRepository;
-//
-//    public TreeService(TreeRepository treeRepository) {
-//        this.treeRepository = treeRepository;
-//    }
-//
-//    public int getCurrentTreeIdByUserId(int userId) {
-//        userService.getUserIdByAuthorizationHeader
-//    }
-//}
+package jupgo.jupgoserver.service;
+
+import jupgo.jupgoserver.domain.tree.Tree;
+import jupgo.jupgoserver.domain.user.User;
+import jupgo.jupgoserver.repository.TreeRepository;
+import jupgo.jupgoserver.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class TreeService {
+
+    private final TreeRepository treeRepository;
+    private final UserRepository userRepository;
+
+    public TreeService(TreeRepository treeRepository, UserRepository userRepository) {
+        this.treeRepository = treeRepository;
+        this.userRepository = userRepository;
+    }
+
+    public void saveTreeInUser(long userId) {
+        User user = userRepository.findById(userId);
+        Tree tree = createTree(user);
+        treeRepository.save(tree);
+    }
+
+    private Tree createTree(User user) {
+        return new Tree(user);
+    }
+}

--- a/src/main/java/jupgo/jupgoserver/service/TreeService.java
+++ b/src/main/java/jupgo/jupgoserver/service/TreeService.java
@@ -1,5 +1,6 @@
 package jupgo.jupgoserver.service;
 
+import java.time.Duration;
 import jupgo.jupgoserver.domain.tree.Tree;
 import jupgo.jupgoserver.domain.user.User;
 import jupgo.jupgoserver.repository.TreeRepository;
@@ -31,5 +32,10 @@ public class TreeService {
 
     public Tree getTreeById(long treeId) {
         return treeRepository.findById(treeId);
+    }
+
+    public void addExperience(Tree tree, int distance, Duration duration) {
+        tree.addExperience(distance, duration);
+        treeRepository.save(tree);
     }
 }

--- a/src/main/java/jupgo/jupgoserver/service/TreeService.java
+++ b/src/main/java/jupgo/jupgoserver/service/TreeService.java
@@ -1,0 +1,19 @@
+//package jupgo.jupgoserver.service;
+//
+//import org.springframework.stereotype.Service;
+//import org.springframework.transaction.annotation.Transactional;
+//
+//@Service
+//@Transactional
+//public class TreeService {
+//
+//    private TreeRepository treeRepository;
+//
+//    public TreeService(TreeRepository treeRepository) {
+//        this.treeRepository = treeRepository;
+//    }
+//
+//    public int getCurrentTreeIdByUserId(int userId) {
+//        userService.getUserIdByAuthorizationHeader
+//    }
+//}

--- a/src/main/java/jupgo/jupgoserver/service/TreeService.java
+++ b/src/main/java/jupgo/jupgoserver/service/TreeService.java
@@ -1,6 +1,8 @@
 package jupgo.jupgoserver.service;
 
 import java.time.Duration;
+import java.util.List;
+import java.util.stream.Collectors;
 import jupgo.jupgoserver.domain.tree.Tree;
 import jupgo.jupgoserver.domain.user.User;
 import jupgo.jupgoserver.dto.tree.ReturnTreeContainDiariesDto;
@@ -42,5 +44,11 @@ public class TreeService {
 
     public ReturnTreeContainDiariesDto getDiariesByTreeId(Long treeId) {
         return new ReturnTreeContainDiariesDto(treeRepository.findById(treeId));
+    }
+
+    public List<ReturnTreeContainDiariesDto> getAllDiariesByTrees(List<Tree> trees) {
+        return trees.stream()
+                .map(tree -> getDiariesByTreeId(tree.getId()))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/jupgo/jupgoserver/service/UserService.java
+++ b/src/main/java/jupgo/jupgoserver/service/UserService.java
@@ -1,6 +1,8 @@
 package jupgo.jupgoserver.service;
 
 
+import java.util.List;
+import jupgo.jupgoserver.domain.tree.Tree;
 import jupgo.jupgoserver.domain.user.User;
 import jupgo.jupgoserver.dto.user.SaveUserResponseDto;
 import jupgo.jupgoserver.repository.UserRepository;
@@ -18,5 +20,16 @@ public class UserService {
         }
         userRepository.save(user);
         return new SaveUserResponseDto(user);
+    }
+
+    public long getCurrentTreeIdByUserId(long userId) {
+        User user = userRepository.findById(userId);
+        System.out.println(user.getId() + " / " + user.getNickname());
+        List<Tree> trees = user.getTrees();
+        if (trees.isEmpty()) {
+            return -1;
+        }
+        Tree currentTree = trees.get(0);
+        return currentTree.getId();
     }
 }

--- a/src/main/java/jupgo/jupgoserver/service/UserService.java
+++ b/src/main/java/jupgo/jupgoserver/service/UserService.java
@@ -35,4 +35,8 @@ public class UserService {
                 .get();
         return currentTree.getId();
     }
+
+    public List<Tree> getTreesByUserId(long userId) {
+        return userRepository.findById(userId).getTrees();
+    }
 }

--- a/src/main/java/jupgo/jupgoserver/service/UserService.java
+++ b/src/main/java/jupgo/jupgoserver/service/UserService.java
@@ -1,6 +1,7 @@
 package jupgo.jupgoserver.service;
 
 
+import java.util.Comparator;
 import java.util.List;
 import jupgo.jupgoserver.domain.tree.Tree;
 import jupgo.jupgoserver.domain.user.User;
@@ -29,7 +30,9 @@ public class UserService {
         if (trees.isEmpty()) {
             return -1;
         }
-        Tree currentTree = trees.get(0);
+        Tree currentTree = trees.stream()
+                .max(Comparator.comparing(Tree::getId))
+                .get();
         return currentTree.getId();
     }
 }

--- a/src/main/java/jupgo/jupgoserver/util/response/Response.java
+++ b/src/main/java/jupgo/jupgoserver/util/response/Response.java
@@ -1,9 +1,9 @@
 package jupgo.jupgoserver.util.response;
 
 public class Response<T>  {
-    private int statusCode;
-    private String message;
-    private T data;
+    private final int statusCode;
+    private final String message;
+    private final T data;
 
     public Response(int statusCode, String message) {
         this.statusCode = statusCode;

--- a/src/main/java/jupgo/jupgoserver/util/response/StatusCode.java
+++ b/src/main/java/jupgo/jupgoserver/util/response/StatusCode.java
@@ -4,6 +4,7 @@ public enum StatusCode {
     OK(200),
     CREATED(201),
     BAD_REQUEST(400),
+    UNAUTHORIZED(401),
     NOT_FOUND(404),
     INTERNAL_ERROR(500);
 

--- a/src/main/java/jupgo/jupgoserver/util/response/StatusMessage.java
+++ b/src/main/java/jupgo/jupgoserver/util/response/StatusMessage.java
@@ -5,6 +5,7 @@ public enum StatusMessage {
     // Diary
     PLOGGING_SAVE_SUCCESS("플로깅 기록 저장 성공"),
     GET_DIARIES_OF_TREE_SUCCESS("특정 나무의 기록 조회 성공"),
+    GET_ALL_DIARIES("모든 플로깅 기록 조회 성공"),
 
     SIGNUP_SUCCESS("회원가입 성공"),
     LOGIN_SUCCESS("로그인 성공"),

--- a/src/main/java/jupgo/jupgoserver/util/response/StatusMessage.java
+++ b/src/main/java/jupgo/jupgoserver/util/response/StatusMessage.java
@@ -4,6 +4,8 @@ public enum StatusMessage {
 
     // Diary
     PLOGGING_SAVE_SUCCESS("플로깅 기록 저장 성공"),
+    GET_DIARIES_OF_TREE_SUCCESS("특정 나무의 기록 조회 성공"),
+
     SIGNUP_SUCCESS("회원가입 성공"),
     LOGIN_SUCCESS("로그인 성공"),
 

--- a/src/main/java/jupgo/jupgoserver/util/response/StatusMessage.java
+++ b/src/main/java/jupgo/jupgoserver/util/response/StatusMessage.java
@@ -8,7 +8,8 @@ public enum StatusMessage {
     LOGIN_SUCCESS("로그인 성공"),
 
     LOGIN_FAIL("로그인 실패"),
-    INTERNAL_ERROR("서버 에러");
+    UNAUTHORIZED("유효하지 않은 토큰입니다."),
+    INTERNAL_ERROR("서버 내부 오류");
 
     private final String message;
 

--- a/src/test/java/jupgo/jupgoserver/domain/tree/ExperienceManagerTest.java
+++ b/src/test/java/jupgo/jupgoserver/domain/tree/ExperienceManagerTest.java
@@ -1,0 +1,21 @@
+package jupgo.jupgoserver.domain.tree;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class ExperienceManagerTest {
+
+    @Test
+    void shouldReturnCorrectPercentageWhenInputLevelAndExperience() {
+        Tree tree = new Tree();
+        printStatus(tree);
+        ExperienceManager.addExperience(tree, 50000);
+        printStatus(tree);
+    }
+
+    private static void printStatus(Tree tree) {
+        System.out.println("Level : " + tree.getLevel());
+        System.out.println("Percentage : " + tree.getPercentage());
+    }
+}

--- a/src/test/java/jupgo/jupgoserver/study/DurationTest.java
+++ b/src/test/java/jupgo/jupgoserver/study/DurationTest.java
@@ -1,0 +1,17 @@
+package jupgo.jupgoserver.study;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+public class DurationTest {
+
+    @Test
+    void durationTest() {
+        String[] timeIndexes = "2:24:07".split(":");
+        String durationFormat =
+                "PT" + timeIndexes[0] + "H" + timeIndexes[1] + "M" + timeIndexes[2] + "S";
+        Duration duration = Duration.parse(durationFormat);
+        System.out.println(duration);
+        System.out.println(duration.getSeconds());
+    }
+}


### PR DESCRIPTION
### Changes
- `POST /api/diary` 구현
    - `Diary` 저장
    - 경험치 계산하여 `Tree`의 `Level`, `Percentage` 변경
- `GET /api/diary/:treeId` 구현
- `GET /api/diary/all` 구현

### Next thing to do
- `GET /api/diary/:treeId
`    - 로그인 한 유저의 `Tree`인지 검증
    - 없는 `treeId` 조회 시 예외 처리
- `DELETE /api/user` 구현