### PR TITLE
[Feat] 회원 탈퇴 & Diary 예외 처리

### DIFF
--- a/src/main/java/jupgo/jupgoserver/controller/DiaryController.java
+++ b/src/main/java/jupgo/jupgoserver/controller/DiaryController.java
@@ -1,7 +1,6 @@
 package jupgo.jupgoserver.controller;
 
 import static jupgo.jupgoserver.util.response.StatusCode.INTERNAL_ERROR;
-import static jupgo.jupgoserver.util.response.StatusCode.NOT_FOUND;
 import static jupgo.jupgoserver.util.response.StatusCode.OK;
 import static jupgo.jupgoserver.util.response.StatusCode.UNAUTHORIZED;
 import static jupgo.jupgoserver.util.response.StatusMessage.*;
@@ -20,7 +19,6 @@ import jupgo.jupgoserver.service.UserService;
 import jupgo.jupgoserver.util.response.Response;
 import jupgo.jupgoserver.util.response.StatusMessage;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -69,7 +67,7 @@ public class DiaryController {
             return new Response(OK.getCode(), PLOGGING_SAVE_SUCCESS.getMessage(), saveDiaryResponseDto);
         } catch (JWTVerificationException e) {
             System.out.println(e);
-            return new Response(UNAUTHORIZED.getCode(), StatusMessage.UNAUTHORIZED.getMessage());
+            return new Response(UNAUTHORIZED.getCode(), StatusMessage.INVALID_TOKEN.getMessage());
         }
         catch (Exception e) {
             System.out.println(e);
@@ -88,15 +86,8 @@ public class DiaryController {
             return new Response(OK.getCode(), GET_DIARIES_OF_TREE_SUCCESS.getMessage(), returnTreeContainDiariesDto);
         } catch (JWTVerificationException e) {
             System.out.println(e);
-            return new Response(UNAUTHORIZED.getCode(), StatusMessage.UNAUTHORIZED.getMessage());
-        } catch (IllegalArgumentException e) {
-            System.out.println(e);
-            return new Response(UNAUTHORIZED.getCode(), StatusMessage.NOT_OWNER_OF_TREE.getMessage());
-        } catch (EmptyResultDataAccessException e) {
-            System.out.println(e);
-            return new Response(NOT_FOUND.getCode(), StatusMessage.NOT_EXIST_TREE.getMessage());
-        }
-        catch (Exception e) {
+            return new Response(UNAUTHORIZED.getCode(), StatusMessage.INVALID_TOKEN.getMessage());
+        } catch (Exception e) {
             System.out.println(e);
             return new Response(INTERNAL_ERROR.getCode(), StatusMessage.INTERNAL_ERROR.getMessage());
         }

--- a/src/main/java/jupgo/jupgoserver/controller/TreeController.java
+++ b/src/main/java/jupgo/jupgoserver/controller/TreeController.java
@@ -1,0 +1,57 @@
+package jupgo.jupgoserver.controller;
+
+
+import static jupgo.jupgoserver.util.response.StatusCode.INTERNAL_ERROR;
+import static jupgo.jupgoserver.util.response.StatusCode.OK;
+import static jupgo.jupgoserver.util.response.StatusCode.UNAUTHORIZED;
+import static jupgo.jupgoserver.util.response.StatusMessage.GET_MY_TREES_SUCCESS;
+import static jupgo.jupgoserver.util.response.StatusMessage.INVALID_TOKEN;
+import static jupgo.jupgoserver.util.response.StatusMessage.PLOGGING_SAVE_SUCCESS;
+
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import java.util.List;
+import jupgo.jupgoserver.domain.tree.Tree;
+import jupgo.jupgoserver.domain.user.User;
+import jupgo.jupgoserver.dto.tree.ReturnTreeContainDiariesDto;
+import jupgo.jupgoserver.dto.tree.ReturnTreeDto;
+import jupgo.jupgoserver.service.JwtService;
+import jupgo.jupgoserver.service.TreeService;
+import jupgo.jupgoserver.service.UserService;
+import jupgo.jupgoserver.util.response.Response;
+import jupgo.jupgoserver.util.response.StatusCode;
+import jupgo.jupgoserver.util.response.StatusMessage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+@RequestMapping("/api/tree")
+public class TreeController {
+    @Autowired
+    private JwtService jwtService;
+    @Autowired
+    private UserService userService;
+    @Autowired
+    private TreeService treeService;
+
+    @ResponseBody
+    @GetMapping("/all")
+    public Response getAllTrees(@RequestHeader("Authorization") String authorizationHeader) throws Exception {
+        try {
+            long userId = jwtService.decode(authorizationHeader.split(" ")[1]).getUser_id();
+            User user = userService.getUserById(userId);
+            List<ReturnTreeDto> returnTreeDtos = treeService.getAllTreesByUser(user);
+            return new Response(OK.getCode(), GET_MY_TREES_SUCCESS.getMessage(), returnTreeDtos);
+        } catch (JWTVerificationException e) {
+            System.out.println(e);
+            return new Response(UNAUTHORIZED.getCode(), INVALID_TOKEN.getMessage());
+        }
+        catch (Exception e) {
+            System.out.println(e);
+            return new Response(INTERNAL_ERROR.getCode(), StatusMessage.INTERNAL_ERROR.getMessage());
+        }
+    }
+}

--- a/src/main/java/jupgo/jupgoserver/controller/TreeController.java
+++ b/src/main/java/jupgo/jupgoserver/controller/TreeController.java
@@ -4,6 +4,7 @@ package jupgo.jupgoserver.controller;
 import static jupgo.jupgoserver.util.response.StatusCode.INTERNAL_ERROR;
 import static jupgo.jupgoserver.util.response.StatusCode.OK;
 import static jupgo.jupgoserver.util.response.StatusCode.UNAUTHORIZED;
+import static jupgo.jupgoserver.util.response.StatusMessage.GET_CURRENT_TREE_SUCCESS;
 import static jupgo.jupgoserver.util.response.StatusMessage.GET_MY_TREES_SUCCESS;
 import static jupgo.jupgoserver.util.response.StatusMessage.INVALID_TOKEN;
 import static jupgo.jupgoserver.util.response.StatusMessage.PLOGGING_SAVE_SUCCESS;
@@ -45,6 +46,29 @@ public class TreeController {
             User user = userService.getUserById(userId);
             List<ReturnTreeDto> returnTreeDtos = treeService.getAllTreesByUser(user);
             return new Response(OK.getCode(), GET_MY_TREES_SUCCESS.getMessage(), returnTreeDtos);
+        } catch (JWTVerificationException e) {
+            System.out.println(e);
+            return new Response(UNAUTHORIZED.getCode(), INVALID_TOKEN.getMessage());
+        }
+        catch (Exception e) {
+            System.out.println(e);
+            return new Response(INTERNAL_ERROR.getCode(), StatusMessage.INTERNAL_ERROR.getMessage());
+        }
+    }
+
+    @ResponseBody
+    @GetMapping("/target")
+    public Response getCurrentTree(@RequestHeader("Authorization") String authorizationHeader) throws Exception {
+        try {
+            long userId = jwtService.decode(authorizationHeader.split(" ")[1]).getUser_id();
+            long treeId = userService.getCurrentTreeIdByUserId(userId);
+            if (treeId == -1) {
+                Tree treeCreated  = treeService.createTreeInUser(userId);
+                treeId = treeCreated.getId();
+            }
+            Tree tree = treeService.getTreeById(treeId);
+            ReturnTreeDto returnTreeDto = new ReturnTreeDto(tree);
+            return new Response(OK.getCode(), GET_CURRENT_TREE_SUCCESS.getMessage(), returnTreeDto);
         } catch (JWTVerificationException e) {
             System.out.println(e);
             return new Response(UNAUTHORIZED.getCode(), INVALID_TOKEN.getMessage());

--- a/src/main/java/jupgo/jupgoserver/controller/TreeController.java
+++ b/src/main/java/jupgo/jupgoserver/controller/TreeController.java
@@ -63,8 +63,7 @@ public class TreeController {
             long userId = jwtService.decode(authorizationHeader.split(" ")[1]).getUser_id();
             long treeId = userService.getCurrentTreeIdByUserId(userId);
             if (treeId == -1) {
-                Tree treeCreated  = treeService.createTreeInUser(userId);
-                treeId = treeCreated.getId();
+                return new Response(OK.getCode(), GET_CURRENT_TREE_SUCCESS.getMessage());
             }
             Tree tree = treeService.getTreeById(treeId);
             ReturnTreeDto returnTreeDto = new ReturnTreeDto(tree);

--- a/src/main/java/jupgo/jupgoserver/controller/UserController.java
+++ b/src/main/java/jupgo/jupgoserver/controller/UserController.java
@@ -43,7 +43,7 @@ public class UserController {
             return new Response(OK.getCode(), StatusMessage.WITHDRAW_SUCCESS.getMessage());
         } catch (JWTVerificationException e) {
             System.out.println(e);
-            return new Response(UNAUTHORIZED.getCode(), StatusMessage.UNAUTHORIZED.getMessage());
+            return new Response(UNAUTHORIZED.getCode(), StatusMessage.INVALID_TOKEN.getMessage());
         } catch (Exception e) {
             return new Response(INTERNAL_ERROR.getCode(), StatusMessage.INTERNAL_ERROR.getMessage());
         }

--- a/src/main/java/jupgo/jupgoserver/controller/UserController.java
+++ b/src/main/java/jupgo/jupgoserver/controller/UserController.java
@@ -1,6 +1,9 @@
 package jupgo.jupgoserver.controller;
 
+import com.auth0.jwt.exceptions.JWTVerificationException;
 import jupgo.jupgoserver.service.AuthService;
+import jupgo.jupgoserver.service.JwtService;
+import jupgo.jupgoserver.service.UserService;
 import jupgo.jupgoserver.util.response.Response;
 import jupgo.jupgoserver.util.response.StatusMessage;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,6 +18,10 @@ import static jupgo.jupgoserver.util.response.StatusCode.INTERNAL_ERROR;
 public class UserController {
     @Autowired
     private AuthService authService;
+    @Autowired
+    private JwtService jwtService;
+    @Autowired
+    private UserService userService;
 
 
     @ResponseBody
@@ -22,6 +29,21 @@ public class UserController {
     public Response login(@RequestParam String code) {
         try {
             return new Response(OK.getCode(), StatusMessage.LOGIN_SUCCESS.getMessage(), authService.kakaoLogin(code));
+        } catch (Exception e) {
+            return new Response(INTERNAL_ERROR.getCode(), StatusMessage.INTERNAL_ERROR.getMessage());
+        }
+    }
+
+    @ResponseBody
+    @DeleteMapping("")
+    public Response withdraw(@RequestHeader("Authorization") String authorizationHeader) throws Exception {
+        try {
+            long userId = jwtService.decode(authorizationHeader.split(" ")[1]).getUser_id();
+            userService.deleteUser(userId);
+            return new Response(OK.getCode(), StatusMessage.WITHDRAW_SUCCESS.getMessage());
+        } catch (JWTVerificationException e) {
+            System.out.println(e);
+            return new Response(UNAUTHORIZED.getCode(), StatusMessage.UNAUTHORIZED.getMessage());
         } catch (Exception e) {
             return new Response(INTERNAL_ERROR.getCode(), StatusMessage.INTERNAL_ERROR.getMessage());
         }

--- a/src/main/java/jupgo/jupgoserver/domain/tree/Tree.java
+++ b/src/main/java/jupgo/jupgoserver/domain/tree/Tree.java
@@ -26,7 +26,7 @@ public class Tree {
     @JoinColumn(name = "user_id")
     private User user;
 
-    @OneToMany(mappedBy = "tree")
+    @OneToMany(mappedBy = "tree", cascade = CascadeType.REMOVE)
     private List<Diary> diaries;
 
     public Tree(User user) {

--- a/src/main/java/jupgo/jupgoserver/domain/user/User.java
+++ b/src/main/java/jupgo/jupgoserver/domain/user/User.java
@@ -1,6 +1,7 @@
 package jupgo.jupgoserver.domain.user;
 
 import java.util.List;
+import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -19,7 +20,7 @@ public class User {
     private String email;
     private String kakaoId;
 
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
     private List<Tree> trees;
 
     public User(SaveUserRequestDto saveUserRequestDto) {

--- a/src/main/java/jupgo/jupgoserver/dto/tree/ReturnTreeDto.java
+++ b/src/main/java/jupgo/jupgoserver/dto/tree/ReturnTreeDto.java
@@ -1,0 +1,42 @@
+package jupgo.jupgoserver.dto.tree;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import jupgo.jupgoserver.domain.tree.Tree;
+import jupgo.jupgoserver.dto.diary.ReturnDiaryDto;
+
+public class ReturnTreeDto {
+    private long id;
+    private String name;
+    private String sort;
+    private int level;
+    private int percentage;
+
+    public ReturnTreeDto(Tree tree) {
+        this.id = tree.getId();
+        this.name = tree.getName();
+        this.sort = tree.getSort();
+        this.level = tree.getLevel();
+        this.percentage = tree.getPercentage();
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getSort() {
+        return sort;
+    }
+
+    public int getLevel() {
+        return level;
+    }
+
+    public int getPercentage() {
+        return percentage;
+    }
+}

--- a/src/main/java/jupgo/jupgoserver/repository/UserRepository.java
+++ b/src/main/java/jupgo/jupgoserver/repository/UserRepository.java
@@ -28,10 +28,9 @@ public class UserRepository {
     }
 
     public User findById(long userId) {
-        List<User> users = em.createQuery("select u from User u where u.id = :userId", User.class)
+        return em.createQuery("select u from User u where u.id = :userId", User.class)
                 .setParameter("userId", userId)
-                .getResultList();
-        return users.get(0);
+                .getSingleResult();
     }
 
 }

--- a/src/main/java/jupgo/jupgoserver/repository/UserRepository.java
+++ b/src/main/java/jupgo/jupgoserver/repository/UserRepository.java
@@ -1,9 +1,7 @@
 package jupgo.jupgoserver.repository;
 import jupgo.jupgoserver.domain.user.User;
 import javax.persistence.EntityManager;
-import javax.transaction.Transactional;
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
@@ -33,4 +31,7 @@ public class UserRepository {
                 .getSingleResult();
     }
 
+    public void deleteById(long userId) {
+        em.remove(findById(userId));
+    }
 }

--- a/src/main/java/jupgo/jupgoserver/service/TreeService.java
+++ b/src/main/java/jupgo/jupgoserver/service/TreeService.java
@@ -23,10 +23,12 @@ public class TreeService {
         this.userRepository = userRepository;
     }
 
-    public void saveTreeInUser(long userId) {
+    public Tree createTreeInUser(long userId) {
         User user = userRepository.findById(userId);
         Tree tree = createTree(user);
         treeRepository.save(tree);
+        user = userRepository.findById(userId);
+        return tree;
     }
 
     private Tree createTree(User user) {
@@ -42,8 +44,17 @@ public class TreeService {
         treeRepository.save(tree);
     }
 
-    public ReturnTreeContainDiariesDto getDiariesByTreeId(Long treeId) {
-        return new ReturnTreeContainDiariesDto(treeRepository.findById(treeId));
+    public ReturnTreeContainDiariesDto getDiariesByTreeIdAfterValidateAuthorization(Long treeId, Long userId) {
+        Tree tree = treeRepository.findById(treeId);
+        if (tree.getUser().getId() != userId) {
+            throw new IllegalArgumentException("로그인 한 유저의 Tree가 아닙니다.");
+        }
+        return new ReturnTreeContainDiariesDto(tree);
+    }
+
+    private ReturnTreeContainDiariesDto getDiariesByTreeId(Long treeId) {
+        Tree tree = treeRepository.findById(treeId);
+        return new ReturnTreeContainDiariesDto(tree);
     }
 
     public List<ReturnTreeContainDiariesDto> getAllDiariesByTrees(List<Tree> trees) {

--- a/src/main/java/jupgo/jupgoserver/service/TreeService.java
+++ b/src/main/java/jupgo/jupgoserver/service/TreeService.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 import jupgo.jupgoserver.domain.tree.Tree;
 import jupgo.jupgoserver.domain.user.User;
 import jupgo.jupgoserver.dto.tree.ReturnTreeContainDiariesDto;
+import jupgo.jupgoserver.dto.tree.ReturnTreeDto;
 import jupgo.jupgoserver.repository.TreeRepository;
 import jupgo.jupgoserver.repository.UserRepository;
 import org.springframework.stereotype.Service;
@@ -60,6 +61,12 @@ public class TreeService {
     public List<ReturnTreeContainDiariesDto> getAllDiariesByTrees(List<Tree> trees) {
         return trees.stream()
                 .map(tree -> getDiariesByTreeId(tree.getId()))
+                .collect(Collectors.toList());
+    }
+
+    public List<ReturnTreeDto> getAllTreesByUser(User user) {
+        return user.getTrees().stream()
+                .map(ReturnTreeDto::new)
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/jupgo/jupgoserver/service/UserService.java
+++ b/src/main/java/jupgo/jupgoserver/service/UserService.java
@@ -24,9 +24,13 @@ public class UserService {
     }
 
     public long getCurrentTreeIdByUserId(long userId) {
+        System.out.println("check in getCurrentTreeIdByUserId");
+        System.out.println("userId: " + userId);
         User user = userRepository.findById(userId);
+        System.out.println("user: " + user);
         System.out.println(user.getId() + " / " + user.getNickname());
         List<Tree> trees = user.getTrees();
+        System.out.println("trees of user: " + trees);
         if (trees.isEmpty()) {
             return -1;
         }

--- a/src/main/java/jupgo/jupgoserver/service/UserService.java
+++ b/src/main/java/jupgo/jupgoserver/service/UserService.java
@@ -8,9 +8,11 @@ import jupgo.jupgoserver.domain.user.User;
 import jupgo.jupgoserver.dto.user.SaveUserResponseDto;
 import jupgo.jupgoserver.repository.UserRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 
 @Service
+@Transactional
 public class UserService {
     private UserRepository userRepository;
     public UserService(UserRepository userRepository) { this.userRepository = userRepository; }
@@ -42,5 +44,9 @@ public class UserService {
 
     public List<Tree> getTreesByUserId(long userId) {
         return userRepository.findById(userId).getTrees();
+    }
+
+    public void deleteUser(long userId) {
+        userRepository.deleteById(userId);
     }
 }

--- a/src/main/java/jupgo/jupgoserver/service/UserService.java
+++ b/src/main/java/jupgo/jupgoserver/service/UserService.java
@@ -49,4 +49,8 @@ public class UserService {
     public void deleteUser(long userId) {
         userRepository.deleteById(userId);
     }
+
+    public User getUserById(long userId) {
+        return userRepository.findById(userId);
+    }
 }

--- a/src/main/java/jupgo/jupgoserver/util/response/StatusMessage.java
+++ b/src/main/java/jupgo/jupgoserver/util/response/StatusMessage.java
@@ -9,6 +9,7 @@ public enum StatusMessage {
 
     SIGNUP_SUCCESS("회원가입 성공"),
     LOGIN_SUCCESS("로그인 성공"),
+    WITHDRAW_SUCCESS("회원탈퇴 성공"),
 
     LOGIN_FAIL("로그인 실패"),
     UNAUTHORIZED("유효하지 않은 토큰입니다."),

--- a/src/main/java/jupgo/jupgoserver/util/response/StatusMessage.java
+++ b/src/main/java/jupgo/jupgoserver/util/response/StatusMessage.java
@@ -9,6 +9,7 @@ public enum StatusMessage {
 
     // Tree
     GET_MY_TREES_SUCCESS("내가 키우는 나무 조회 성공"),
+    GET_CURRENT_TREE_SUCCESS("현재 키우는 나무 조회 성공"),
 
     SIGNUP_SUCCESS("회원가입 성공"),
     LOGIN_SUCCESS("로그인 성공"),

--- a/src/main/java/jupgo/jupgoserver/util/response/StatusMessage.java
+++ b/src/main/java/jupgo/jupgoserver/util/response/StatusMessage.java
@@ -7,12 +7,15 @@ public enum StatusMessage {
     GET_DIARIES_OF_TREE_SUCCESS("특정 나무의 기록 조회 성공"),
     GET_ALL_DIARIES("모든 플로깅 기록 조회 성공"),
 
+    // Tree
+    GET_MY_TREES_SUCCESS("내가 키우는 나무 조회 성공"),
+
     SIGNUP_SUCCESS("회원가입 성공"),
     LOGIN_SUCCESS("로그인 성공"),
     WITHDRAW_SUCCESS("회원탈퇴 성공"),
 
     LOGIN_FAIL("로그인 실패"),
-    UNAUTHORIZED("유효하지 않은 토큰입니다."),
+    INVALID_TOKEN("유효하지 않은 토큰입니다."),
     NOT_OWNER_OF_TREE("로그인 한 유저의 나무가 아닙니다."),
     NOT_EXIST_TREE("존재하지 않는 나무의 id입니다."),
     INTERNAL_ERROR("서버 내부 오류");

--- a/src/main/java/jupgo/jupgoserver/util/response/StatusMessage.java
+++ b/src/main/java/jupgo/jupgoserver/util/response/StatusMessage.java
@@ -12,6 +12,8 @@ public enum StatusMessage {
 
     LOGIN_FAIL("로그인 실패"),
     UNAUTHORIZED("유효하지 않은 토큰입니다."),
+    NOT_OWNER_OF_TREE("로그인 한 유저의 나무가 아닙니다."),
+    NOT_EXIST_TREE("존재하지 않는 나무의 id입니다."),
     INTERNAL_ERROR("서버 내부 오류");
 
     private final String message;


### PR DESCRIPTION
### Changes
- `GET /api/diary/:treeId`
    - 로그인 한 유저의 `Tree`인지 검증
    - 없는 `treeId` 조회 시 예외 처리
- `DELETE /api/user` 구현
- `POST /api/diary` 첫 저장 시, Tree만 저장되고 Diary 저장되지 않는 에러 수정